### PR TITLE
To configure alertManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ## Ignore user-generated secrets for some pre-reqs
 *env.secret
 *.secret
+gitops-applications/alertManager/alertmanager.yaml

--- a/gitops-applications/alertManager/README.md
+++ b/gitops-applications/alertManager/README.md
@@ -1,0 +1,5 @@
+# Configuring AlertManager for Red Hat Advanced Cluster Management
+
+To configure _AlertManager_ for _Red Hat Advanced Cluster Management_ you should only update the `alertmanager-config` secret in the
+`open-cluster-management-observability` namespace.  `cp alertmanager.yam.example` to `alertmanager.yaml`, Fill out the URL of the incoming (webhook)[https://api.slack.com/messaging/webhooks] from the slack workspace and channel where `alertManager` will propagatre the alerts.
+Running $ oc replace -k .` will replace the `alertmanager.yaml`.

--- a/gitops-applications/alertManager/alertmanager.yaml.example
+++ b/gitops-applications/alertManager/alertmanager.yaml.example
@@ -1,0 +1,48 @@
+global:
+  slack_api_url: https://hooks.slack.com/services/<MAGIC TOKEN>
+inhibit_rules:
+  - equal:
+      - namespace
+      - alertname
+    source_match:
+      severity: critical
+    target_match_re:
+      severity: warning|info
+  - equal:
+      - namespace
+      - alertname
+    source_match:
+      severity: warning
+    target_match_re:
+      severity: info
+route:
+  group_by:
+    - namespace
+    - alertname
+    - service
+    - cluster
+  group_interval: 1m
+  group_wait: 30s
+  receiver: Warning
+  repeat_interval: 12h
+  routes:
+    - receiver: Critical
+      match:
+        severity: critical
+    - receiver: Warning
+      match:
+        severity: warning
+
+receivers:
+  - name: Warning
+    slack_configs:
+      - channel: '#<CHANNEL_NAME>'
+        icon_emoji: ':warning:'
+        username: SRE AlertManager
+        text: '{{ template "slack.default.text" .}}'
+  - name: Critical
+    slack_configs:
+      - channel: '#<CHANNEL_NAME>'
+        username: SRE AlertManager
+        icon_emoji: ':rotating_light:'
+        text: '{{ template "slack.default.text" .}}'

--- a/gitops-applications/alertManager/kustomization.yaml
+++ b/gitops-applications/alertManager/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+namespace: open-cluster-management-observability
+
+secretGenerator:
+- name: alertmanager-config
+  files:
+  - alertmanager.yaml


### PR DESCRIPTION
@gurnben this is a very preliminary PR but it does the job. There's no need of `operators` folder since to configure _AlertManager_ we just need to replace the `alertmanager-config` secret in `open-cluster-management-observability`.

Unluckily I couldn't put the `slack_api_url` in `slack_api_url_file` field 'cause I ran into an error like this: `component=configuration msg="Loading configuration file failed" file=/etc/alertmanager/config/alertmanager.yaml err="yaml: unmarshal errors:\n  line 2: field slack_api_url_file not found in type config.plain"`.
Keep working on this.

Again, it's simplistic but it works: keep working on this.

