### PR TITLE
remove AutomationControllerResponseError alert

### DIFF
--- a/alerts/README.md
+++ b/alerts/README.md
@@ -14,7 +14,6 @@ AAPPodFrequentlyRestarting | AAP Pod in `ansible-automation-platform` namespace 
 AAPPodNotReady | AAP Pod in `ansible-automation-platform` namespace has been in a non-ready state for longer than 15 minutes
 AAPPodRestartingTooMuch | AAP Pod in `ansible-automation-platform` namespace restart more than 10 times over 10 minutes
 AAPStatefulSetReplicasMismatch | AAP StatefulSet in `ansible-automation-platform` namespace actual number of replicas is inconsistent with the set number of replicas over 5 minutes
-AutomationControllerResponseError | AAP controller in `ansible-automation-platform` namespace response error (status="500") is more than 3 over 5 minutes. To enable this alert, we should install vector to AAP AKS cluster to collect AAP controller log events and push to ACM Hub. For more information, please refer to [this doc](https://github.com/stolostron/acm-aap-aas-operations/tree/main/operators/vector)
 
 ## Adding an alert
 

--- a/alerts/base/custom_rules.yaml
+++ b/alerts/base/custom_rules.yaml
@@ -1,16 +1,6 @@
 groups:
-- name: aap-health
+- name: AnsibleAutomationPlatform
   rules:
-  - alert: AutomationControllerResponseError
-    annotations:
-      description: AAP controller in {{$labels.namespace}} response error (status="500") is more than 3 over 5 minutes
-      summary: AAP controller in {{$labels.namespace}} response error
-    expr: automation_controller_response_total{status="500"} > 3
-    for: 5m
-    labels:
-      severity: warning
-      team: aap-sre
-      runbook: https://github.com/stolostron/sre-doc/blob/main/runbook/AutomationControllerResponseError.md
   - alert: AAPPodRestartingTooMuch
     annotations:
       description: AAP Pod in {{$labels.namespace}} restart more than 10 times over 10 minutes


### PR DESCRIPTION
I would like to delete this alert. because this alert just to capture some logs like this:
```
10.244.0.142 - admin [24/Jan/2022:13:49:58 +0000] "GET /api/v2/metrics HTTP/1.1" 500 0 "-" "Prometheus/2.26.1" "-"
10.244.0.142 - admin [24/Jan/2022:13:50:58 +0000] "GET /api/v2/metrics HTTP/1.1" 200 0 "-" "Prometheus/2.26.1" "-"
```
we just use this log format to develop a log collector prototype.

Signed-off-by: Song Song Li <ssli@redhat.com>