### PR TITLE
Customize Argocd image include Vault plugin and referenced by ArgoCD CR

### DIFF
--- a/cluster-bootstrap/openshift-gitops/config/argocd.yaml
+++ b/cluster-bootstrap/openshift-gitops/config/argocd.yaml
@@ -75,6 +75,8 @@ spec:
       g, aap-aas-demo-admin, role:admin
     scopes: '[groups]'
   repo:
+    image: quay.io/ocm-observability/argovault
+    mountsatoken: true
     resources:
       limits:
         cpu: '1'
@@ -82,27 +84,8 @@ spec:
       requests:
         cpu: 250m
         memory: 256Mi
-    initContainers:
-      - command:
-          - /bin/sh
-          - '-c'
-          - >-
-            curl -v  -LJ --tls-max 1.2
-            https://github.com/argoproj-labs/argocd-vault-plugin/releases/download/v1.8.0/argocd-vault-plugin_1.8.0_linux_amd64
-            -o argocd-vault-plugin && chmod -v +x argocd-vault-plugin
-        image: 'registry.redhat.io/ubi8/ubi:latest'
-        name: install-vault
-        volumeMounts:
-          - mountPath: /vault-plugin
-            name: vault-plugin
-        workingDir: /vault-plugin
-    volumeMounts:
-      - mountPath: /usr/local/bin/argocd-vault-plugin
-        name: vault-plugin
-        subPath: argocd-vault-plugin
-    volumes:
-      - emptyDir: {}
-        name: vault-plugin
+    serviceaccount: vplugin
+    version: v1.0
     env:
       - name: VAULT_ADDR
         value: <VAULT_ADDRESS>

--- a/cluster-bootstrap/openshift-gitops/config/argocd.yaml
+++ b/cluster-bootstrap/openshift-gitops/config/argocd.yaml
@@ -76,7 +76,7 @@ spec:
     scopes: '[groups]'
   repo:
     image: quay.io/ocm-observability/argovault
-    mountsatoken: true
+    version: v1.0
     resources:
       limits:
         cpu: '1'
@@ -84,8 +84,6 @@ spec:
       requests:
         cpu: 250m
         memory: 256Mi
-    serviceaccount: vplugin
-    version: v1.0
     env:
       - name: VAULT_ADDR
         value: <VAULT_ADDRESS>


### PR DESCRIPTION
Create a Argocd image that contains the argo vault plugin. So this way, we don't need to download vault plugin during container init and this could resolve the case in some private cluster that no proxy configed for container init stage.