### PR TITLE
To add python virtual env for ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ansible-playbooks/kubeconfig
 *.DS_Store
 *.vscode
 ansible-playbooks/default.yml
+ansibe-playbooks/venv/

--- a/ansible-playbooks/Makefile
+++ b/ansible-playbooks/Makefile
@@ -1,0 +1,17 @@
+VIRTUALENV="./venv"
+PIP=$(VIRTUALENV)/bin/pip3
+ANSIBLE-GALAXY=$(VIRTUALENV)/bin/ansible-galaxy
+ANSIBLE-PLAYBOOK=$(VIRTUALENV)/bin/ansible-playbook
+
+all: venv 
+
+venv:
+	LC_ALL=en_US.UTF-8 python3 -m venv $(VIRTUALENV)
+	. $(VIRTUALENV)/bin/activate
+	$(PIP) install ansible==2.10
+	$(PIP) install kubernetes
+	$(ANSIBLE-GALAXY) collection install kubernetes.core
+	$(VIRTUALENV)/bin/python3 -m pip install --upgrade pip
+
+clean-venv:
+	rm -fr $(VIRTUALENV)

--- a/ansible-playbooks/README.md
+++ b/ansible-playbooks/README.md
@@ -84,6 +84,8 @@ To import with this playbook:
 ```bash
 git clone ...
 cd acm-aap-aas-operations/ansible-playbooks
+make venv
+source venv/bin/activate
 
 # create the vars file and populate with your aks information
 ansible-playbook playbooks/import-aap-aks.yml -e "@default.yml"


### PR DESCRIPTION
This is needed to avoid conflicts between `az cli` and `ansible-playbook' during the _import_. More on the way.