### PR TITLE
to get rid of AKS_NAME from ansible vars and fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ ansible-playbooks/kubeconfig
 *.DS_Store
 *.vscode
 ansible-playbooks/default.yml
-ansibe-playbooks/venv/
+ansible-playbooks/venv/

--- a/ansible-playbooks/README.md
+++ b/ansible-playbooks/README.md
@@ -100,7 +100,6 @@ This default.yml need not be checked in.
 ```yaml
 cluster_name: aks-...-centralus
 AKS_MRG: mrg-...-preview-20220331094426
-AKS_NAME: aks-...-centralus
 AKS_SUB: e47e6908-...
 HUB_RG: acm-dev-6wbm8-rg
 HUB_SUB: 4da397a2-...

--- a/ansible-playbooks/roles/import-managedcluster-default-invoke/tasks/main.yml
+++ b/ansible-playbooks/roles/import-managedcluster-default-invoke/tasks/main.yml
@@ -26,7 +26,7 @@
   shell: |-
     IMPORT_BLOB=$(cat {{ tempdir.path }}/{{ item }} | base64 -w 0)
     az aks command invoke --resource-group {{ AKS_MRG }} \
-      --name {{ AKS_NAME }} \
+      --name {{ cluster_name }} \
       --subscription {{ AKS_SUB }} \
       --command "echo $IMPORT_BLOB | base64 --decode | kubectl apply -f -"
   with_items:
@@ -39,7 +39,7 @@
     oc get managedcluster {{ cluster_name }} -n {{ cluster_name }} -o yaml
     az aks command invoke \
       --resource-group {{ AKS_MRG }} \
-      --name {{ AKS_NAME }} \
+      --name {{ cluster_name }} \
       --subscription {{ AKS_SUB }} \
       --command "kubectl get ns; kubectl get pods -n open-cluster-management-agent"
   register: hubspoke_out
@@ -63,7 +63,7 @@
   shell: |-
     IMPORT_BLOB=$(cat {{ tempdir.path }}/{{ item }} | base64 -w 0)
     az aks command invoke --resource-group {{ AKS_MRG }} \
-      --name {{ AKS_NAME }} \
+      --name {{ cluster_name }} \
       --subscription {{ AKS_SUB }} \
       --command "echo $IMPORT_BLOB | base64 --decode | kubectl delete -f -"
   with_items:


### PR DESCRIPTION
@cdoan1 as discussed `AKS_NAME` and `cluster_name` both variables represent the name of the cluster. Getting rid of `AKS_NAME`. In this PR I also fix a typo in `.gitignore` file.
Thanks to have a look