### PR TITLE
Add Cert manager config

### DIFF
--- a/cluster-bootstrap/argocd-apps/dev/cert-manager-config/application.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/cert-manager-config/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: cluster-bootstrap/cert-manager-config/overlay/dev
+    repoURL: https://github.com/stolostron/acm-aap-aas-operations.git
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin-kustomize
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster-bootstrap/argocd-apps/dev/cert-manager-config/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/cert-manager-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- application.yaml

--- a/cluster-bootstrap/argocd-apps/stage/cert-manager-config/application.yaml
+++ b/cluster-bootstrap/argocd-apps/stage/cert-manager-config/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: cluster-bootstrap/cert-manager-config/overlay/stage
+    repoURL: https://github.com/stolostron/acm-aap-aas-operations.git
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin-kustomize
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster-bootstrap/argocd-apps/stage/cert-manager-config/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/stage/cert-manager-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- application.yaml

--- a/cluster-bootstrap/cert-manager-config/base/kustomization.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- private.clusterissuer.yaml

--- a/cluster-bootstrap/cert-manager-config/base/namespace.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-bootstrap/cert-manager-config/base/private.clusterissuer.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/private.clusterissuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}

--- a/cluster-bootstrap/cert-manager-config/overlay/dev/aws.public.clusterissuer.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/dev/aws.public.clusterissuer.yaml
@@ -1,0 +1,32 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: public-issuer
+  namespace: cert-manager
+  annotations:
+    avp.kubernetes.io/path: "/sre-dev/data/cert-issuer"
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  acme:
+    email: acm-cicd@redhat.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: haproxy
+      selector:
+        matchLabels:
+          use-http01-solver: "true"
+    - dns01:
+        cnameStrategy: Follow
+        route53:
+          accessKeyID: <AWS_ACCESS_KEY_ID>
+          region: us-east-1
+          secretAccessKeySecretRef:
+            key: aws_secret_access_key
+            name: aws-creds
+      selector:
+        matchLabels:
+          use-dns01-solver: "true"

--- a/cluster-bootstrap/cert-manager-config/overlay/dev/aws.secret.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/dev/aws.secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-creds
+  namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    avp.kubernetes.io/path: "/sre-dev/data/cert-issuer"
+type: Opaque
+stringData:
+  aws_access_key_id: <AWS_ACCESS_KEY_ID>
+  aws_secret_access_key: <AWS_SECRET_ACCESS_KEY>

--- a/cluster-bootstrap/cert-manager-config/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/dev/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+patchesJson6902:
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: apps-domain-tls-cert
+    namespace: openshift-ingress
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'apps.demo-aws-495-7nspt.demo.red-chesterfield.com'
+    - op: replace
+      path: /spec/dnsNames/1
+      value: '*.apps.demo-aws-495-7nspt.demo.red-chesterfield.com'
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: api-domain-tls-cert
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'api.apps.demo-aws-495-7nspt.demo.red-chesterfield.com'
+
+resources:
+- ../../base
+- aws.secret.yaml
+- aws.public.clusterissuer.yaml

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/api.certificate.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/api.certificate.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-domain-tls-cert
+  namespace: openshift-config
+  labels:
+    use-dns01-solver: "true"
+spec:
+  secretName: api-domain-tls
+  subject:
+    organizations:
+    - Open Cluster Management
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - api.openshift-cluster-name.base-domain.tld
+  duration: 720h0m0s
+  renewBefore: 168h0m0s
+  privateKey:
+    algorithm: "RSA"
+    size: 2048
+  issuerRef:
+    name: public-issuer
+    kind: ClusterIssuer

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/apps.certificate.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/apps.certificate.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: apps-domain-tls-cert
+  namespace: openshift-ingress
+  labels:
+    use-dns01-solver: "true"
+spec:
+  secretName: apps-domain-tls
+  subject:
+    organizations:
+    - Open Cluster Management
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - apps.openshift-cluster-name.base-domain.tld
+    - "*.apps.openshift-cluster-name.base-domain.tld"
+  duration: 720h0m0s
+  renewBefore: 168h0m0s
+  privateKey:
+    algorithm: "RSA"
+    size: 2048
+  issuerRef:
+    name: public-issuer
+    kind: ClusterIssuer

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/azure.public.clusterissuer.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/azure.public.clusterissuer.yaml
@@ -1,0 +1,37 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: public-issuer
+  namespace: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  acme:
+    email: acm-cicd@redhat.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: haproxy
+      selector:
+        matchLabels:
+          use-http01-solver: "true"
+    - dns01:
+        cnameStrategy: Follow
+        azureDNS:
+          clientID: AZURE_CERT_MANAGER_SP_APP_ID
+          clientSecretSecretRef:
+          # The following is the secret we created in Kubernetes. Issuer will use this to present challenge to Azure DNS.
+            name: azuredns-config
+            key: client-secret
+          subscriptionID: AZURE_SUBSCRIPTION_ID
+          tenantID: AZURE_TENANT_ID
+          resourceGroupName: AZURE_DNS_ZONE_RESOURCE_GROUP
+          hostedZoneName: AZURE_DNS_ZONE
+          # Azure Cloud Environment, default to AzurePublicCloud
+          environment: AzurePublicCloud
+      selector:
+        matchLabels:
+          use-dns01-solver: "true"

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/azure.secret.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/azure.secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azuredns-config
+  namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    avp.kubernetes.io/path: "/sre-dev/data/cert-issuer"
+type: Opaque
+stringData:
+  client-secret: <AZURE_CLIENT_SECRET>

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/azure.secret.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/azure.secret.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-operators
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
-    avp.kubernetes.io/path: "/sre-dev/data/cert-issuer"
+    avp.kubernetes.io/path: "/sre-stage/data/cert-issuer"
 type: Opaque
 stringData:
   client-secret: <AZURE_CLIENT_SECRET>

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/kustomization.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/kustomization.yaml
@@ -3,29 +3,6 @@ kind: Kustomization
 
 patchesJson6902:
 - target:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: apps-domain-tls-cert
-    namespace: openshift-ingress
-  patch: |-
-    - op: replace
-      path: /spec/dnsNames/0
-      value: 'apps.acm-dev.az.aoc.lab'
-    - op: replace
-      path: /spec/dnsNames/1
-      value: '*.apps.acm-dev.az.aoc.lab'
-- target:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: api-domain-tls-cert
-    namespace: openshift-config
-  patch: |-
-    - op: replace
-      path: /spec/dnsNames/0
-      value: 'api.acm-dev.az.aoc.lab'
-- target:
     kind: ClusterIssuer
     group: cert-manager.io
     version: v1
@@ -51,5 +28,3 @@ patchesJson6902:
 resources:
 - azure.secret.yaml
 - azure.public.clusterissuer.yaml
-- api.certificate.yaml
-- apps.certificate.yaml

--- a/cluster-bootstrap/cert-manager-config/overlay/stage/kustomization.yaml
+++ b/cluster-bootstrap/cert-manager-config/overlay/stage/kustomization.yaml
@@ -1,0 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+patchesJson6902:
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: apps-domain-tls-cert
+    namespace: openshift-ingress
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'apps.acm-dev.az.aoc.lab'
+    - op: replace
+      path: /spec/dnsNames/1
+      value: '*.apps.acm-dev.az.aoc.lab'
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: api-domain-tls-cert
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'api.acm-dev.az.aoc.lab'
+- target:
+    kind: ClusterIssuer
+    group: cert-manager.io
+    version: v1
+    name: public-issuer
+    namespace: cert-manager
+  patch: |-
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/clientID
+      value: 'dc22ed4f-cbdd-49fc-beb1-ea3f282b50ee'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/subscriptionID
+      value: 'c7130a18-cbc9-4b44-9307-1f56446fb730'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/tenantID
+      value: '6047c7e9-b2ad-488d-a54e-dc3f6be6a7ee'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/resourceGroupName
+      value: 'openshift4-terraform'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/hostedZoneName
+      value: 'az.aoc.lab'
+
+resources:
+- azure.secret.yaml
+- azure.public.clusterissuer.yaml
+- api.certificate.yaml
+- apps.certificate.yaml


### PR DESCRIPTION
Fo dev env, created private issuer. As dev env may have various domains according to different env developer created by himself, so let developer config as his wish.

For stage env, created private and public issuer. No certificates created for api and app, as current stage env is private and domain name is not valid public. So it will not work.