### PR TITLE
add alert for policy

### DIFF
--- a/cluster-bootstrap/multicluster-observability/base/custom-alerts/README.md
+++ b/cluster-bootstrap/multicluster-observability/base/custom-alerts/README.md
@@ -14,7 +14,10 @@ AAPPodFrequentlyRestarting | AAP Pod in `ansible-automation-platform` namespace 
 AAPPodNotReady | AAP Pod in `ansible-automation-platform` namespace has been in a non-ready state for longer than 15 minutes
 AAPPodRestartingTooMuch | AAP Pod in `ansible-automation-platform` namespace restart more than 10 times over 10 minutes
 AAPStatefulSetReplicasMismatch | AAP StatefulSet in `ansible-automation-platform` namespace actual number of replicas is inconsistent with the set number of replicas over 5 minutes
+PolicyNotCompliant | Policy is not compliant for longer than 5 minutes
 
 ## Adding an alert
 
 If you want to add an alert based on collected metrics. Please following [this guide](https://github.com/stolostron/sre-doc/blob/main/guides/how-to-define-alert.md) to define a new alert and make sure you have the required fields for alert.
+
+You can find some useful alerts from this page: [Awesome Prometheus alerts](https://awesome-prometheus-alerts.grep.to/rules.html)

--- a/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts.yaml
+++ b/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts.yaml
@@ -79,3 +79,16 @@ data:
           team: acm-sre
           service: aap
           runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPStatefulSetReplicasMismatch.md
+    - name: AdvancedClusterManagement
+      rules:
+      - alert: PolicyNotCompliant
+        annotations:
+          description: Policy {{$labels.policy}} is not compliant on {{$labels.cluster}} for longer than 5 minutes
+          summary: Policy is not compliant
+        expr: sum(policy:policy_governance_info:propagated_noncompliant_count) by (cluster, clusterID, policy) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: acm-sre
+          service: policy
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/advanced-cluster-management/PolicyNotCompliant.md


### PR DESCRIPTION
We should define some policy-related alerts base on these policy-related metrics, because we use the policy to configure the ​​Prometheus and alertMgr