### PR TITLE
Add configuration to encrypt etcd on the OpenShift cluster

### DIFF
--- a/cluster-bootstrap/argocd-apps/dev/openshift-config/application.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/openshift-config/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openshift-config
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: cluster-bootstrap/openshift-config/overlay/dev
+    repoURL: https://github.com/stolostron/acm-aap-aas-operations.git
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin-kustomize
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster-bootstrap/argocd-apps/dev/openshift-config/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/openshift-config/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+- application.yaml

--- a/cluster-bootstrap/argocd-apps/dev/patch-operator/application.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/patch-operator/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: patch-operator
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: cluster-bootstrap/patch-operator/overlay/dev
+    repoURL: https://github.com/stolostron/acm-aap-aas-operations.git
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin-kustomize
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster-bootstrap/argocd-apps/dev/patch-operator/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/patch-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+- application.yaml

--- a/cluster-bootstrap/argocd-apps/stage/openshift-config/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/stage/openshift-config/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources: []

--- a/cluster-bootstrap/argocd-apps/stage/patch-operator/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/stage/patch-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources: []

--- a/cluster-bootstrap/openshift-config/README.md
+++ b/cluster-bootstrap/openshift-config/README.md
@@ -1,0 +1,3 @@
+This is used to deploy OpenShift configuration.
+
+This can use Patch operator or plain resources.

--- a/cluster-bootstrap/openshift-config/base/apiserver-patch.yaml
+++ b/cluster-bootstrap/openshift-config/base/apiserver-patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  name: apiserver
+  namespace: openshift-gitops
+spec:
+  serviceAccountRef:
+    name: openshift-gitops-argocd-application-controller
+  patches:
+    apiserver-etcd:
+      targetObjectRef:
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        name: cluster
+      patchTemplate: |
+        spec:
+          encryption:
+            type: aescbc
+      patchType: application/merge-patch+json

--- a/cluster-bootstrap/openshift-config/base/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+  - apiserver-patch.yaml

--- a/cluster-bootstrap/openshift-config/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/overlay/dev/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+bases:
+- ../../base
+

--- a/cluster-bootstrap/patch-operator/base/kustomization.yaml
+++ b/cluster-bootstrap/patch-operator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- subscription.yaml
+- operatorgroup.yaml

--- a/cluster-bootstrap/patch-operator/base/namespace.yaml
+++ b/cluster-bootstrap/patch-operator/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: patch-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-bootstrap/patch-operator/base/operatorgroup.yaml
+++ b/cluster-bootstrap/patch-operator/base/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: patch-operator
+  namespace: patch-operator
+spec:
+  targetNamespaces: []

--- a/cluster-bootstrap/patch-operator/base/subscription.yaml
+++ b/cluster-bootstrap/patch-operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: patch-operator
+  namespace: patch-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: patch-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-bootstrap/patch-operator/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/patch-operator/overlay/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,4 +46,10 @@ kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/prometheus-config
 printf "=====================Create Cert-manager application ...\n"
 kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/cert-manager
 
+printf "=====================Create Patch-operator application ...\n"
+kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/patch-operator
+
+printf "=====================Create openshift-config application ...\n"
+kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/openshift-config
+
 printf "Cluster bootstrap completed with ACM, MultiCluster Observability, Grafana-dev, Prometheus config and custom Alters & Metrics!\n\n"


### PR DESCRIPTION
This is done through patch-operator, as we want to patch
an existing resource. Possible alternatives:
- committing the full object, which could be an issue for upgrades
- running patch command from a playbook