### PR TITLE
add policy to check metrics collector

### DIFF
--- a/cluster-bootstrap/acm-policy/base/check-metrics-collector.yaml
+++ b/cluster-bootstrap/acm-policy/base/check-metrics-collector.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: check-metrics-collector
+  namespace: open-cluster-management-observability
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-1 Baseline Configuration
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-metrics-collector
+        spec:
+          remediationAction: inform
+          severity: low
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - open-cluster-management-addon-observability
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: metrics-collector-deployment
+
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-check-metrics-collector
+  namespace: open-cluster-management-observability
+placementRef:
+  name: placement-check-metrics-collector
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: check-metrics-collector
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-check-metrics-collector
+  namespace: open-cluster-management-observability
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions: []

--- a/cluster-bootstrap/acm-policy/base/check-metrics-collector.yaml
+++ b/cluster-bootstrap/acm-policy/base/check-metrics-collector.yaml
@@ -31,7 +31,14 @@ spec:
                 kind: Deployment
                 metadata:
                   name: metrics-collector-deployment
-
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: observability.open-cluster-management.io/v1beta1
+                kind: ObservabilityAddon
+                metadata:
+                  name: observability-addon
+                spec:
+                  enableMetrics: true
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/cluster-bootstrap/acm-policy/base/kustomization.yaml
+++ b/cluster-bootstrap/acm-policy/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: open-cluster-management-observability
+
+resources:
+- check-metrics-collector.yaml

--- a/cluster-bootstrap/acm-policy/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/acm-policy/overlay/dev/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: open-cluster-management-observability
+
+resources:
+- ../../base

--- a/cluster-bootstrap/argocd-apps/dev/acm-policy/application.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/acm-policy/application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: acm
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: cluster-bootstrap/acm-policy/overlay/dev
+    repoURL: https://github.com/stolostron/acm-aap-aas-operations.git
+    targetRevision: main
+    plugin:
+      name: argocd-vault-plugin-kustomize
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster-bootstrap/argocd-apps/dev/acm-policy/kustomization.yaml
+++ b/cluster-bootstrap/argocd-apps/dev/acm-policy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+- application.yaml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,4 +80,10 @@ kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/patch-operator
 printf "=====================Create openshift-config application ...\n"
 kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/openshift-config
 
+printf "=====================Create alertmanager-to-github application ...\n"
+kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/alertmanager-to-github
+
+printf "=====================Create acm-policy application ...\n"
+kubectl apply -k ./cluster-bootstrap/argocd-apps/$1/acm-policy
+
 printf "✓ Cluster bootstrap completed with ACM, MultiCluster Observability, Grafana-dev, Prometheus config and custom Alters & Metrics!\n\n"


### PR DESCRIPTION
To ensure that all managedclusters have the metrics collector deployment. that means we should enable the observability for all managedcluster.
Signed-off-by: Song Song Li <ssli@redhat.com>