### PR TITLE
restore improvements after restore-acm1.az.mgmtdev.ansiblecloud.com c…

### DIFF
--- a/ansible-playbooks/Backup-and-Restore.md
+++ b/ansible-playbooks/Backup-and-Restore.md
@@ -50,9 +50,12 @@ Create the `default.yml` for ansible variables
 
 ```shell
 (venv)$ cat default.yml
-HUB_RG:  ... # hub resource group
-HUB_SUB: ... # hub azure subscription
-HUB_PDNSZ: ... # hub dns zone
+HUB_RG:  ... # hub to restore resource group
+HUB_SUB: ... # hub to restore azure subscription
+HUB_PDNSZ: ... # hub to restore private dns zone
+
+OLD_HUB_PDNSZ: ... # hub backed up private dns zone
+
 
 STORAGE_RESOURCEGROUP: ... # storage resource group
 STORAGE_CONTAINER: ... # azure storage container

--- a/ansible-playbooks/roles/connect-aks-to-acm-hub-collection/tasks/cleanup-for-restore.yml
+++ b/ansible-playbooks/roles/connect-aks-to-acm-hub-collection/tasks/cleanup-for-restore.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: show role parameters
+- name: show me the info
   debug:
-    msg: "Deleting connection to HUB for AKS {{ AKS_NAME }} in RG {{AKS_MRG}} in subscription {{AKS_SUB}}"
+    msg: "Cleanup for restore for AKS {{ AKS_NAME }} in RG {{AKS_MRG}} in subscription {{AKS_SUB}}"
 
 - name: Get facts for virtual network info
   azure.azcollection.azure_rm_virtualnetwork_info:
@@ -42,7 +42,7 @@
     resource_group: "{{ AKS_MRG }}"
     relative_name: "*.apps"
     subscription_id: "{{ AKS_SUB }}"
-    zone_name: "{{ HUB_PDNSZ }}"
+    zone_name: "{{ OLD_HUB_PDNSZ }}"
     record_type: A
     records:
       - entry: "{{ item.ip_configurations[0].private_ip_address }}"
@@ -56,7 +56,7 @@
     resource_group: "{{ AKS_MRG }}"
     relative_name: "api"
     subscription_id: "{{ AKS_SUB }}"
-    zone_name: "{{ HUB_PDNSZ }}"
+    zone_name: "{{ OLD_HUB_PDNSZ }}"
     record_type: A
     records:
       - entry: "{{ item.ip_configurations[0].private_ip_address }}"
@@ -70,7 +70,7 @@
     resource_group: "{{ AKS_MRG }}"
     relative_name: "api-int"
     subscription_id: "{{ AKS_SUB }}"
-    zone_name: "{{ HUB_PDNSZ }}"
+    zone_name: "{{ OLD_HUB_PDNSZ }}"
     record_type: A
     records:
       - entry: "{{ item.ip_configurations[0].private_ip_address }}"
@@ -98,8 +98,8 @@
 - name: Delete private dns zone link
   azure.azcollection.azure_rm_privatednszonelink:
     resource_group: "{{ AKS_MRG }}"
-    name: "{{ HUB_PDNSZ }}-link"
-    zone_name: "{{ HUB_PDNSZ }}"
+    name: "{{ OLD_HUB_PDNSZ }}-link"
+    zone_name: "{{ OLD_HUB_PDNSZ }}"
     virtual_network: "{{ AKS_VNET }}"
     subscription_id: "{{ AKS_SUB }}"
     registration_enabled: yes
@@ -110,7 +110,7 @@
 - name: Delete private dns zone
   azure.azcollection.azure_rm_privatednszone:
     resource_group: "{{ AKS_MRG }}"
-    name: "{{ HUB_PDNSZ }}"
+    name: "{{ OLD_HUB_PDNSZ }}"
     subscription_id: "{{ AKS_SUB }}"
     state: absent
     tags:

--- a/ansible-playbooks/roles/connect-aks-to-acm-hub-collection/tasks/create.yml
+++ b/ansible-playbooks/roles/connect-aks-to-acm-hub-collection/tasks/create.yml
@@ -1,35 +1,13 @@
 ---
 
-- name: Get facts for resource group info
-  azure.azcollection.azure_rm_resourcegroup_info:
-    name: "{{ AKS_MRG }}"
-    list_resources: true
+- name: show me the info
+  debug:
+    msg: "Creating connection to ACM HUB for  AKS:{{ AKS_NAME }}, in Resource Group:{{ AKS_MRG  }}, Subscription:{{ AKS_SUB }} "
+
 
 - name: Get facts for virtual network info
   azure.azcollection.azure_rm_virtualnetwork_info:
     resource_group: "{{ AKS_MRG }}"
-    subscription_id: "{{ AKS_SUB }}"
-  register: vnetinfo
-
-- name: if no vnet found  fetch vnet info from AKS
-  azure.azcollection.azure_rm_aks_info:
-    resource_group: "{{ AKS_MRG }}"
-    subscription_id: "{{ AKS_SUB }}"
-    name: "{{ AKS_NAME }}"
-  register: aksinfo
-  when: (vnetinfo.virtualnetworks | length == 0)
-
-# Set  AKS_VNET_RG from aksinfo otherwise fallback to AKS_MRG
-- set_fact:
-    AKS_VNET_RG: "{{ aksinfo is defined | ternary(aksinfo.aks[0].properties.nodeResourceGroup, AKS_MRG) }}"
-
-- name: Show me the parameter
-  debug:
-    msg: "AKS Name:{{ AKS_NAME }}, Resource-Group:{{ AKS_MRG  }}, Vnet RG: {{ AKS_VNET_RG }}, Subscription:{{ AKS_SUB }} "
-
-- name: redefine vnetinfo
-  azure.azcollection.azure_rm_virtualnetwork_info:
-    resource_group: "{{ AKS_VNET_RG }}"
     subscription_id: "{{ AKS_SUB }}"
   register: vnetinfo
 
@@ -44,7 +22,7 @@
 
 - name: Create private dns zone
   azure.azcollection.azure_rm_privatednszone:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     name: "{{ HUB_PDNSZ }}"
     subscription_id: "{{ AKS_SUB }}"
     tags:
@@ -52,7 +30,7 @@
 
 - name: Create a virtual network link
   azure.azcollection.azure_rm_privatednszonelink:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     name: "{{ HUB_PDNSZ }}-link"
     zone_name: "{{ HUB_PDNSZ }}"
     virtual_network: "{{ AKS_VNET }}"
@@ -64,7 +42,7 @@
 
 - name: Disable network policies on subnet
   azure.azcollection.azure_rm_subnet:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     name: "{{ AKS_SUBNET.name }}"
     virtual_network_name: "{{ AKS_VNET }}"
     subscription_id: "{{ AKS_SUB }}"
@@ -83,7 +61,7 @@
 - name: Create private endpoint connected to private link
   azure.azcollection.azure_rm_privateendpoint:
     name: "{{ item.name }}-pe"
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     subscription_id: "{{ AKS_SUB }}"
     private_link_service_connections:
       - name: "{{ item.name }}-cn"
@@ -97,7 +75,7 @@
 
 - name: Get network interfaces within a resource group
   azure.azcollection.azure_rm_networkinterface_info:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     subscription_id: "{{ AKS_SUB }}"
   register: NIC_MAP
 
@@ -107,7 +85,7 @@
 
 - name: ensure an "A" record set with multiple records - *.apps
   azure.azcollection.azure_rm_privatednsrecordset:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     relative_name: "*.apps"
     subscription_id: "{{ AKS_SUB }}"
     zone_name: "{{ HUB_PDNSZ }}"
@@ -120,7 +98,7 @@
 
 - name: ensure an "A" record set with multiple records - api
   azure.azcollection.azure_rm_privatednsrecordset:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     relative_name: "api"
     subscription_id: "{{ AKS_SUB }}"
     zone_name: "{{ HUB_PDNSZ }}"
@@ -133,7 +111,7 @@
 
 - name: ensure an "A" record set with multiple records - api-int
   azure.azcollection.azure_rm_privatednsrecordset:
-    resource_group: "{{ AKS_VNET_RG }}"
+    resource_group: "{{ AKS_MRG }}"
     relative_name: "api-int"
     subscription_id: "{{ AKS_SUB }}"
     zone_name: "{{ HUB_PDNSZ }}"

--- a/ansible-playbooks/roles/enable-oadp-object-storage/tasks/main.yml
+++ b/ansible-playbooks/roles/enable-oadp-object-storage/tasks/main.yml
@@ -7,6 +7,7 @@
 # - STORAGE_ACCOUNT
 # - STORAGE_SUBSCRIPTION
 
+#TOD (sdminonne): this for restore should be replaced with an _info to prevent creation
 - name: ensure storage account exists
   azure_rm_storageaccount:
     resource_group: "{{ STORAGE_RESOURCEGROUP }}"
@@ -22,13 +23,12 @@
 - set_fact:
     STORAGE_KEY: "{{ key.stdout }}"
 
-
+#TODO (sdminonne): this for restore should be replaced with an _info to prevent creation
 - name: Ensure storage container exist
   azure_rm_storageblob:
     resource_group: "{{ STORAGE_RESOURCEGROUP }}"
     storage_account_name: "{{ STORAGE_ACCOUNT }}"
     container: "{{STORAGE_CONTAINER}}"
-
 
 - name: Create temporary file
   ansible.builtin.tempfile:
@@ -36,13 +36,10 @@
     suffix: temp
   register: tempfile_1
 
-
-
 - name: generate storage secret
   template:
     src: ../roles/enable-oadp-object-storage/templates/cloud-credentials-azure
     dest: "{{ tempfile_1.path }}"
-
 
 - name: Create storage secret
   kubernetes.core.k8s:
@@ -56,7 +53,6 @@
         namespace: openshift-adp
       data:
         cloud: "{{ lookup('file',  '{{tempfile_1.path}}'  ) | b64encode }}"
-
 
 - name: Create openshift oadp operator
   kubernetes.core.k8s:

--- a/ansible-playbooks/roles/enable-oadp-operator/tasks/main.yml
+++ b/ansible-playbooks/roles/enable-oadp-operator/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# configure the openshift oadp operator
 
 - name: Create openshift oadp operator
   kubernetes.core.k8s:

--- a/ansible-playbooks/roles/restore-hub/tasks/main.yml
+++ b/ansible-playbooks/roles/restore-hub/tasks/main.yml
@@ -34,46 +34,50 @@
   kubernetes.core.k8s_info:
     api_version: cluster.open-cluster-management.io/v1
     kind: ManagedCluster
-  register: managedcluster_list
+    label_selectors:
+      - velero.io/restore-name #To get only restored clusters
+  register: restored_managedclusters
 
-#TODO: double check only managedcluster with label key velero.io/restore-name
-#TODO remove 'local-cluster' from mc_lists
-- set_fact:
-    mc_lists: "{{  managedcluster_list.resources | map(attribute='metadata.name') | list }}"
-
-- name: Collect AKS in subscription
-  azure_rm_aks_info:
-    subscription_id: "{{ AKS_SUB }}"
-  register: aks_list
-
-- set_fact:
-    aks_ids : "{{ aks_list.aks | json_query(jmesquery) }}"
-  vars:
-    jmesquery: "[*].{ID: id}"
-
-- name: deconnect AKS
-  include_tasks: ../roles/connect-aks-to-acm-hub-collection/tasks/delete.yml
-  vars:
-     AKS_NAME:  "{{  aks_item.ID.split('/')[8] }}"
-     AKS_MRG: "{{ aks_item.ID.split('/')[4] }}"
-  loop: "{{ aks_ids }}"
+# Iterate over restored managed clusters and collect their name skipping the already Joined ones
+- set_fact: mc_lists="{{ (mc_lists | default([])) + ([ mc_item.metadata.name ])}}"
+  loop: "{{ restored_managedclusters.resources }}"
   loop_control:
-    loop_var: aks_item
-  when: ( aks_item.ID.split('/')[8] in {{ mc_lists }} )
--
-name: Let's pause 20s to let private dns zone fade away
+    loop_var: mc_item
+  when: mc_item.status.conditions is defined  and "ManagedClusterAvailable" not in (mc_item.status.conditions | map(attribute='reason'))
+
+
+- name: retrieve  all AKS across all subcrtiptions
+  shell: for subid in $(az account list --query [].id -o tsv); do az aks list --subscription $subid --query [].id -o tsv; done
+  register: list_all_aks_x_accounts
+
+- set_fact:
+    aks_IDs: "{{ list_all_aks_x_accounts.stdout }}"
+
+- name: deconnect AKS from {{OLD_HUB_PDNSZ}} and attach to {{ HUB_PDNSZ }}
+  include_tasks: ../roles/connect-aks-to-acm-hub-collection/tasks/cleanup-for-restore.yml
+  vars:
+     AKS_NAME:  "{{ aks_id.split('/')[8] }}"
+     AKS_MRG: "{{ aks_id.split('/')[4] }}"
+     AKS_SUB: "{{ aks_id.split('/')[2] }}"
+  loop: "{{ aks_IDs.splitlines() }}"
+  loop_control:
+    loop_var: aks_id
+  when: ( aks_id.split('/')[8] in {{ mc_lists }} )
+
+- name: Let's pause 20s to let private dns zone fade away
   wait_for:
     timeout: 20
 
 - name: reconnect AKS
   include_tasks: ../roles/connect-aks-to-acm-hub-collection/tasks/create.yml
   vars:
-     AKS_NAME:  "{{  aks_item.ID.split('/')[8] }}"
-     AKS_MRG: "{{ aks_item.ID.split('/')[4] }}"
-  loop: "{{ aks_ids }}"
+     AKS_NAME:  "{{ aks_id.split('/')[8] }}"
+     AKS_MRG: "{{ aks_id.split('/')[4] }}"
+     AKS_SUB: "{{ aks_id.split('/')[2] }}"
+  loop: "{{ aks_IDs.splitlines() }}"
   loop_control:
-    loop_var: aks_item
-  when: ( aks_item.ID.split('/')[8] in {{ mc_lists }} )
+    loop_var: aks_id
+  when: ( aks_id.split('/')[8] in {{ mc_lists }} )
 
 - name: Let's pause 20s to let private endpoint/linksvc connect correctly
   wait_for:
@@ -82,9 +86,10 @@ name: Let's pause 20s to let private dns zone fade away
 - name: re-import AKS
   include_tasks: ../roles/import-managedcluster-default-invoke/tasks/create.yml
   vars:
-     AKS_NAME:  "{{  aks_item.ID.split('/')[8] }}"
-     AKS_MRG: "{{ aks_item.ID.split('/')[4] }}"
-  loop: "{{ aks_ids }}"
+     AKS_NAME:  "{{ aks_id.split('/')[8] }}"
+     AKS_MRG: "{{ aks_id.split('/')[4] }}"
+     AKS_SUB: "{{ aks_id.split('/')[2] }}"
+  loop: "{{ aks_IDs.splitlines() }}"
   loop_control:
-    loop_var: aks_item
-  when: ( aks_item.ID.split('/')[8] in {{ mc_lists }} )
+    loop_var: aks_id
+  when: ( aks_id.split('/')[8] in {{ mc_lists }} )


### PR DESCRIPTION
This PR adds  all the improvements after the restore of `acm1.az.mgmtdev.ansiblecloud.com`
Basicaylly

1. The cleanup of the previous HUB private dns zone is now driven by an ansible var `OLD_HUB_PDNSZ` (to prevent deletion of application private DNS) in a specific [role/task](https://github.com/stolostron/acm-aap-aas-operations/compare/main...sdminonne:restore-managed-app?expand=1#diff-d4fd3e5b2922c85c2ac96f3699c848584f2c0f5371e3a1aaca2155fd49b3fe5b) 
2. Code to import  private aks (not managed app) has been removed for simplicity. I'll create a specific role for that but in another PR (if possible)
3. the main restore-hub task now list only restored cluster (with velero label) and don't try to restore already imported cluster (for idem-potency)
4. replaced all the `with_items` with `loop/loop_var` since all those `item`s are a real PITA re-using `roles`

@cdoan1 Thanks for having a look @andreadecorte @zkayyali812 (if you've cycles :) )