### PR TITLE
Remove tag from argovault image

### DIFF
--- a/cluster-bootstrap/openshift-gitops/config/argocd.yaml
+++ b/cluster-bootstrap/openshift-gitops/config/argocd.yaml
@@ -76,6 +76,7 @@ spec:
     scopes: '[groups]'
   repo:
     image: quay.io/acm-sre/argovault
+    version: latest
     resources:
       limits:
         cpu: '1'

--- a/cluster-bootstrap/openshift-gitops/config/argocd.yaml
+++ b/cluster-bootstrap/openshift-gitops/config/argocd.yaml
@@ -75,7 +75,7 @@ spec:
       g, aap-aas-demo-admin, role:admin
     scopes: '[groups]'
   repo:
-    image: quay.io/acm-sre/argovault:latest
+    image: quay.io/acm-sre/argovault
     resources:
       limits:
         cpu: '1'


### PR DESCRIPTION
Signed-off-by: Zachary Kayyali <zkayyali@redhat.com>
It appears that tags should not be added at this image reference - https://argocd-operator.readthedocs.io/en/latest/reference/argocd/#dex-example


With the tag, the deployment is configured to try and pull the following image - 
`quay.io/acm-sre/argovault:latest@sha256:dd738f234fcdb0aac8631a0fd1aafbbcd86f936480b06e8377b033ef7a764f71` which will fail as it has both a tag and SHA

Currently, after removing the tag, it is attempting to use just the SHA, but this is still failing to pull since the SHA is not valid. I am not sure as of now how the SHA is getting injected here