### PR TITLE
upgrade dev cluster acm1 to acm 2.5

### DIFF
--- a/cluster-bootstrap/grafana-dev/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/grafana-dev/overlay/dev/kustomization.yaml
@@ -8,11 +8,11 @@ resources:
 images:
 - name: quay.io/stolostron/grafana
   newName: quay.io/stolostron/grafana
-  newTag: 2.4.2-SNAPSHOT-2022-01-10-20-20-33
+  newTag: 2.5.0-SNAPSHOT-2022-06-08-14-23-40
 
 - name: quay.io/stolostron/grafana-dashboard-loader
   newName: quay.io/stolostron/grafana-dashboard-loader
-  newTag: 2.4.2-SNAPSHOT-2022-01-10-20-20-33
+  newTag: 2.5.0-SNAPSHOT-2022-06-08-14-23-40
 
 patchesJson6902:
 - target:

--- a/cluster-bootstrap/multicluster-observability/overlay/dev/aap-alerts.yaml
+++ b/cluster-bootstrap/multicluster-observability/overlay/dev/aap-alerts.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    note: generated
+  labels:
+    type: generated
+  name: thanos-ruler-custom-rules
+  namespace: open-cluster-management-observability
+data:
+  custom_rules.yaml: |
+    groups:
+    - name: AnsibleAutomationPlatform
+      rules:
+      - alert: AAPMetricEndpointDown
+        annotations:
+          description: AAP metric endpoint has disappeared from Prometheus target discovery
+          summary: Target disappeared from Prometheus target discovery
+        expr: |
+            sum(up{namespace="ansible-automation-platform", job="automation-controller-service"}) != sum(acm_managed_cluster_info{managed_cluster_id!=""}) - 1
+            or absent(up{namespace="ansible-automation-platform", job="automation-controller-service"}) == 1
+        for: 15m
+        labels:
+          severity: critical
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPMetricEndpointDown.md
+      - alert: AAPPodRestartingTooMuch
+        annotations:
+          description: AAP Pod in {{$labels.namespace}} restart more than 100 times over 60 minutes
+          summary: AAP Pod in {{$labels.namespace}} restarting too much
+        expr: sum(kube_pod_container_status_restarts_total{namespace="ansible-automation-platform"}) by (cluster, namespace, pod, container) > 100
+        for: 60m
+        labels:
+          severity: warning
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPPodRestartingTooMuch.md
+      - alert: AAPPodFrequentlyRestarting
+        annotations:
+          description: AAP Pod in {{$labels.namespace}} is restarting {{ printf "%.2f" $value }} times over 2 minutes
+          summary: AAP Pod in {{$labels.namespace}} frequently restarting
+        expr: increase(kube_pod_container_status_restarts_total{namespace="ansible-automation-platform"}[1m]) > 3
+        for: 2m
+        labels:
+          severity: warning
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPPodFrequentlyRestarting.md
+      - alert: AAPPodContainerTerminated
+        annotations:
+          description: AAP Pod in {{$labels.namespace}} has been in terminated state for longer than 10 minutes
+          summary: AAP Pod in {{$labels.namespace}} has been in terminated state
+        expr: kube_pod_container_status_terminated_reason{reason=~"OOMKilled|Error|ContainerCannotRun", namespace="ansible-automation-platform"} > 0
+        for: 10m
+        labels:
+          severity: critical
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPPodContainerTerminated.md
+      - alert: AAPPodNotReady
+        annotations:
+          description: AAP Pod in {{$labels.namespace}} has been in a non-ready state for longer than 15 minutes
+          summary: AAP Pod in {{$labels.namespace}} not ready
+        expr: min_over_time(sum by (cluster, namespace, pod, container) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed",namespace="ansible-automation-platform"})[15m:1m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPPodNotReady.md
+      - alert: AAPDeploymentReplicasMismatch
+        annotations:
+          description: AAP Deployment in {{$labels.namespace}} actual number of replicas is inconsistent with the set number of replicas over 5 minutes
+          summary: AAP Deployment in {{$labels.namespace}} does not match the expected number of replicas
+        expr: kube_deployment_status_replicas_available{namespace="ansible-automation-platform"} != kube_deployment_spec_replicas{namespace="ansible-automation-platform"}
+        for: 5m
+        labels:
+          severity: critical
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPDeploymentReplicasMismatch.md
+      - alert: AAPStatefulSetReplicasMismatch
+        annotations:
+          description: AAP StatefulSet in {{$labels.namespace}} actual number of replicas is inconsistent with the set number of replicas over 5 minutes
+          summary: AAP StatefulSet in {{$labels.namespace}} does not match the expected number of replicas
+        expr: kube_statefulset_status_replicas_available{namespace="ansible-automation-platform"} != kube_statefulset_replicas{namespace="ansible-automation-platform"}
+        for: 5m
+        labels:
+          severity: critical
+          team: aoc-sre
+          service: aap
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPStatefulSetReplicasMismatch.md
+    - name: AdvancedClusterManagement
+      rules:
+      - alert: PolicyNotCompliant
+        annotations:
+          description: Policy {{$labels.policy}} in the namespace {{$labels.cluster_namespace}} is not compliant on cluster {{$labels.cluster_namespace}} for longer than 5 minutes
+          summary: Policy is not compliant
+        expr: sum(policy_governance_info{type="propagated"}) by (cluster_namespace, policy, cluster) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: acm-sre
+          service: policy
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/advanced-cluster-management/PolicyNotCompliant.md
+      - alert: MetricsCollectorMissing
+        annotations:
+          description: Metrics collector Pod missing on some managed clusters for longer than 10 minutes
+          summary: Metrics collector Pod missing on some managed clusters
+        expr: sum(kube_pod_info{namespace="open-cluster-management-addon-observability", pod=~"metrics-collector-deployment.*"}) != sum(acm_managed_cluster_info{clusterID!=""})
+        for: 10m
+        labels:
+          severity: critical
+          team: acm-sre
+          service: observability
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/advanced-cluster-management/MetricsCollectorMissing.md
+      - alert: ManagedClusterMissing
+        annotations:
+          description: Managed cluster missing from ACM Hub for longer than 10 minutes
+          summary: Managed cluster missing from ACM Hub
+        expr: sum(kube_namespace_labels{label_cluster_open_cluster_management_io_managed_cluster!=""}) != sum(acm_managed_cluster_info{managed_cluster_id!=""})
+        for: 10m
+        labels:
+          severity: critical
+          team: acm-sre
+          service: managedcluster
+          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/advanced-cluster-management/ManagedClusterMissing.md

--- a/cluster-bootstrap/multicluster-observability/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/multicluster-observability/overlay/dev/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 - ../../base
 - multiclusterhub-operator-pull-secret.yaml
 - thanos-storage-aws-secret.yaml
+
+patchesStrategicMerge:
+- aap-alerts.yaml

--- a/cluster-bootstrap/prometheus-config/overlay/dev/aap-prom-conf-policy.yaml
+++ b/cluster-bootstrap/prometheus-config/overlay/dev/aap-prom-conf-policy.yaml
@@ -1,0 +1,95 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: prom-conf-policy
+  namespace: open-cluster-management-addon-observability
+  annotations:
+    policy.open-cluster-management.io/standards: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/categories: NIST SP 800-53
+    policy.open-cluster-management.io/controls: CM Configuration Management
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: prom-conf-policy
+      spec:
+        namespaceSelector:
+          exclude:
+            - kube-*
+          include:
+            - open-cluster-management-addon-observability
+        object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              data:
+                user: YWRtaW4K
+                password: '{{fromSecret "ansible-automation-platform" "automation-controller-admin-password" "password"}}'
+              kind: Secret
+              metadata:
+                name: automation-controller-auth
+                namespace: open-cluster-management-addon-observability
+              type: Opaque
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: monitoring.coreos.com/v1
+              kind: ServiceMonitor
+              metadata:
+                name: aap-metrics
+                namespace: open-cluster-management-addon-observability
+              spec:
+                selector:
+                  matchLabels:
+                    app.kubernetes.io/name: automation-controller
+                namespaceSelector:
+                  matchNames:
+                  - ansible-automation-platform
+                endpoints:
+                - port: metrics
+                  honorLabels: false
+                  interval: 30s
+                  path: /api/v2/metrics
+                  basicAuth:
+                    password:
+                      name: automation-controller-auth
+                      key: password
+                    username:
+                      name: automation-controller-auth
+                      key: user
+        remediationAction: inform
+        severity: low
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-prom-conf-policy
+  namespace: open-cluster-management-addon-observability
+placementRef:
+  name: placement-prom-conf-policy
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: prom-conf-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-prom-conf-policy
+  namespace: open-cluster-management-addon-observability
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - AKS

--- a/cluster-bootstrap/prometheus-config/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/prometheus-config/overlay/dev/kustomization.yaml
@@ -5,3 +5,6 @@ namespace: open-cluster-management-observability
 
 resources:
 - ../../base
+
+patchesStrategicMerge:
+- aap-prom-conf-policy.yaml


### PR DESCRIPTION
we do not want to impact the prod env, so create a PR to only update the dev cluster manifests, when the prod upgraded to acm 2.5, merge this change to prod env.

/hold