### PR TITLE
Add policy to control OpenShift version upgrade on the Hub

### DIFF
--- a/cluster-bootstrap/openshift-config/base/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/base/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 namespace: openshift-gitops
 
 resources:
+  - policy-openshift-cluster-version.yaml
   - apiserver-patch.yaml

--- a/cluster-bootstrap/openshift-config/base/policy-openshift-cluster-version.yaml
+++ b/cluster-bootstrap/openshift-config/base/policy-openshift-cluster-version.yaml
@@ -1,0 +1,77 @@
+
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: upgrade-cluster-policy
+  namespace: openshift-config
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: upgrade-cluster-conf-policy
+        spec:
+          remediationAction: inform
+          severity: low
+          evaluationInterval:
+            compliant: 1m
+            noncompliant: 1m
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - openshift-config       
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: config.openshift.io/v1
+                kind: ClusterVersion
+                metadata:
+                  name: version
+                spec:
+                  clusterID: '{{ (lookup "config.openshift.io/v1" "ClusterVersion" "" "version").spec.clusterID }}'
+                  channel: stable-4.10
+                  desiredUpdate:
+                    #force: true
+                    version: 4.10.16
+  remediationAction: enforce
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-upgrade-cluster-policy
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+placementRef:
+  name: placement-upgrade-cluster-policy
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: upgrade-cluster-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-upgrade-cluster-policy
+  namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - local-cluster

--- a/cluster-bootstrap/openshift-config/overlay/dev/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/overlay/dev/kustomization.yaml
@@ -7,3 +7,13 @@ bases:
 - ../../base
 - apiserver-certs-patch.yaml
 - apps-ingresscontroller-patch.yaml
+
+patches:
+- target:
+    kind: Policy
+    name: upgrade-cluster-policy
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/disabled
+      value: true

--- a/cluster-bootstrap/openshift-config/overlay/local/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/overlay/local/kustomization.yaml
@@ -5,3 +5,13 @@ namespace: openshift-gitops
 
 bases:
 - ../../base
+
+patches:
+- target:
+    kind: Policy
+    name: upgrade-cluster-policy
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/disabled
+      value: true

--- a/cluster-bootstrap/openshift-config/overlay/prod/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/overlay/prod/kustomization.yaml
@@ -5,3 +5,13 @@ namespace: openshift-gitops
 
 bases:
 - ../../base
+
+patches:
+- target:
+    kind: Policy
+    name: upgrade-cluster-policy
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/disabled
+      value: true

--- a/cluster-bootstrap/openshift-config/overlay/testing/kustomization.yaml
+++ b/cluster-bootstrap/openshift-config/overlay/testing/kustomization.yaml
@@ -7,3 +7,13 @@ bases:
 - ../../base
 - apiserver-certs-patch.yaml
 - apps-ingresscontroller-patch.yaml
+
+patches:
+- target:
+    kind: Policy
+    name: upgrade-cluster-policy
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/disabled
+      value: true


### PR DESCRIPTION
It will be deployed disabled in all the environments