### PR TITLE
Fix ArgoCD RBAC with the correct group name, as the demo one does not exist

### DIFF
--- a/ansible-playbooks/roles/deploy-acm-stack/templates/argocd.yaml.j2
+++ b/ansible-playbooks/roles/deploy-acm-stack/templates/argocd.yaml.j2
@@ -72,7 +72,7 @@ spec:
       g, system:cluster-admins, role:admin
       g, shared-infrastructure-admins, role:admin
       g, admins, role:admin
-      g, aap-aas-demo-admin, role:admin
+      g, aap-aas-admin, role:admin
     scopes: '[groups]'
   repo:
     image: quay.io/acm-sre/argovault

--- a/cluster-bootstrap/openshift-gitops/config/argocd.yaml
+++ b/cluster-bootstrap/openshift-gitops/config/argocd.yaml
@@ -72,7 +72,7 @@ spec:
       g, system:cluster-admins, role:admin
       g, shared-infrastructure-admins, role:admin
       g, admins, role:admin
-      g, aap-aas-demo-admin, role:admin
+      g, aap-aas-admin, role:admin
     scopes: '[groups]'
   repo:
     image: quay.io/acm-sre/argovault


### PR DESCRIPTION
>  oc get group aap-aas-demo-admin
> Error from server (NotFound): groups.user.openshift.io "aap-aas-demo-admin" not found

oc get group aap-aas-admin
NAME            USERS
aap-aas-admin   ...