### PR TITLE
Add a policyset to group certificates related policies

### DIFF
--- a/cluster-bootstrap/cert-manager-config/base/azure.public.clusterissuer.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/azure.public.clusterissuer.yaml
@@ -59,38 +59,3 @@ spec:
           remediationAction: inform
           severity: low
   remediationAction: enforce
----
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: binding-azure-clusterissuer-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-placementRef:
-  name: placement-azure-clusterissuer-policy
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: azure-clusterissuer-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: placement-azure-clusterissuer-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: name
-        operator: In
-        values:
-          - local-cluster
-

--- a/cluster-bootstrap/cert-manager-config/base/certificateexpirationpolicy.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/certificateexpirationpolicy.yaml
@@ -24,37 +24,3 @@ spec:
           remediationAction: inform
           severity: low
   remediationAction: inform
----
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: binding-certification-expiration-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-placementRef:
-  name: placement-certification-expiration-policy
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: certification-expiration-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: placement-certification-expiration-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: name
-        operator: In
-        values:
-          - local-cluster

--- a/cluster-bootstrap/cert-manager-config/base/policyset-certificates.yaml
+++ b/cluster-bootstrap/cert-manager-config/base/policyset-certificates.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: certificates-policyset
+  namespace: cert-manager
+spec:
+  description: "Grouping policies related to certificate handling"
+  policies:
+    - azure-clusterissuer-policy
+    - cert-manager-csv-policy
+    - certification-expiration-policy
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-certificates-policyset
+  namespace: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+placementRef:
+  name: placement-certificates-policyset
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: certificates-policyset
+    kind: PolicySet
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-certificates-policyset
+  namespace: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - local-cluster

--- a/cluster-bootstrap/cert-manager/base/csvpatch.yaml
+++ b/cluster-bootstrap/cert-manager/base/csvpatch.yaml
@@ -48,37 +48,3 @@ spec:
           remediationAction: inform
           severity: low
   remediationAction: enforce
----
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: binding-cert-manager-csv-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-placementRef:
-  name: placement-cert-manager-csv-policy
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: cert-manager-csv-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: placement-cert-manager-csv-policy
-  namespace: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: name
-        operator: In
-        values:
-          - local-cluster


### PR DESCRIPTION
so there is no need to repeat bindings objects in the single policies
2.5 only feature