### PR TITLE
Align RHAAPDEV KV setup with Prod tenants

### DIFF
--- a/ansible-playbooks/roles/aap-controller-acm-workflow-secret-sync/vars/vars-rhaapdev.yml
+++ b/ansible-playbooks/roles/aap-controller-acm-workflow-secret-sync/vars/vars-rhaapdev.yml
@@ -1,3 +1,3 @@
 acm_aoc_configuration_repo: "https://gitlab.cee.redhat.com/acm-sre/acm-aoc-configuration.git"
 acm_aoc_configuration_repo_version: "main"
-vault_uri: "https://kv-aoc-team.vault.azure.net"
+vault_uri: "https://kv-acm-sre-rhaapdev.vault.azure.net"

--- a/ansible-playbooks/roles/aap-controller-acm-workflow-setup/vars/vars-rhaapdev.yml
+++ b/ansible-playbooks/roles/aap-controller-acm-workflow-setup/vars/vars-rhaapdev.yml
@@ -12,7 +12,7 @@ worker_instance_type: "Standard_D8ds_v5"
 # AAP setup
 controller_host: "https://controller.mgmtdev.ansiblecloud.com"
 inventory_source_name: "azure-rhaapdev"
-vault_uri: "https://kv-aoc-team.vault.azure.net"
+vault_uri: "https://kv-acm-sre-rhaapdev.vault.azure.net"
 # ArgoCD
 argocd_env: "dev"
 # Additional public DNS Setup


### PR DESCRIPTION
Use a dedicated Azure Key Vault in rg-acm resource group instead of a shared one