### PR TITLE
add new alert for AAP

### DIFF
--- a/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts-policy.yaml
+++ b/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts-policy.yaml
@@ -40,13 +40,37 @@ spec:
                     groups:
                     - name: AnsibleAutomationPlatform
                       rules:
+                      - alert: AAPMetricMissing
+                        annotations:
+                          description: AAP metric missing, the number of samples should be equal to 44, the current value is {{`{{$value}}`}}
+                        expr: scrape_samples_scraped{job="automation-controller-service",namespace="ansible-automation-platform"} < 44
+                        for: 10m
+                        labels:
+                          severity: warning
+                          team: aoc-sre
+                          service: aap
+                          acm_console: https://{{(lookup "route.openshift.io/v1" "Route" "open-cluster-management" "multicloud-console").spec.host }}{{`/multicloud/infrastructure/clusters/managed`}}
+                          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPMetricMissing.md
+                      - alert: AAPEndpointAddressNotReady
+                        annotations:
+                          description: AAP endpoint address is not ready
+                        expr: kube_endpoint_address_not_ready{namespace="ansible-automation-platform"} != 0
+                        for: 10m
+                        labels:
+                          severity: critical
+                          team: aoc-sre
+                          service: aap
+                          acm_console: https://{{(lookup "route.openshift.io/v1" "Route" "open-cluster-management" "multicloud-console").spec.host }}{{`/multicloud/infrastructure/clusters/managed`}}
+                          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPEndpointAddressNotReady.md
                       - alert: AAPMetricEndpointDown
                         annotations:
                           description: AAP metric endpoint has disappeared from Prometheus target discovery
                           summary: Target disappeared from Prometheus target discovery
                         expr: |
+                            # the number of AAP clusters and health instances are not equal
                             sum(up{namespace="ansible-automation-platform", job="automation-controller-service"}) != sum(acm_managed_cluster_info{managed_cluster_id!="", available="True"}) - 1
-                            or (absent(up{namespace="ansible-automation-platform", job="automation-controller-service"}) == 1 and sum(acm_managed_cluster_info{managed_cluster_id!="", available="True"}) == 1)
+                            # all AAP service down
+                            or absent(up{namespace="ansible-automation-platform", job="automation-controller-service"}) == 1
                         for: 20m
                         labels:
                           severity: critical

--- a/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts-policy.yaml
+++ b/cluster-bootstrap/multicluster-observability/base/custom-alerts/aap-alerts-policy.yaml
@@ -51,13 +51,24 @@ spec:
                           service: aap
                           acm_console: https://{{(lookup "route.openshift.io/v1" "Route" "open-cluster-management" "multicloud-console").spec.host }}{{`/multicloud/infrastructure/clusters/managed`}}
                           runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPMetricMissing.md
-                      - alert: AAPEndpointAddressNotReady
+                      - alert: AAPEndpointAddressNotAvailable
                         annotations:
-                          description: AAP endpoint address is not ready
-                        expr: kube_endpoint_address_not_ready{namespace="ansible-automation-platform"} != 0
+                          description: AAP endpoint {{`{{$labels.endpoint}}`}} address is not available
+                        expr: kube_endpoint_address_available{namespace="ansible-automation-platform"} == 0
                         for: 10m
                         labels:
                           severity: critical
+                          team: aoc-sre
+                          service: aap
+                          acm_console: https://{{(lookup "route.openshift.io/v1" "Route" "open-cluster-management" "multicloud-console").spec.host }}{{`/multicloud/infrastructure/clusters/managed`}}
+                          runbook_url: https://github.com/stolostron/sre-doc/blob/main/runbooks/ansible-automation-platform-operator/AAPEndpointAddressNotAvailable.md
+                      - alert: AAPEndpointAddressNotReady
+                        annotations:
+                          description: AAP endpoint {{`{{$labels.endpoint}}`}} has {{`{{$value}}`}} addresses which is not ready
+                        expr: kube_endpoint_address_not_ready{namespace="ansible-automation-platform"} != 0
+                        for: 10m
+                        labels:
+                          severity: warning
                           team: aoc-sre
                           service: aap
                           acm_console: https://{{(lookup "route.openshift.io/v1" "Route" "open-cluster-management" "multicloud-console").spec.host }}{{`/multicloud/infrastructure/clusters/managed`}}

--- a/cluster-bootstrap/multicluster-observability/base/custom-metrics/custom-metrics.yaml
+++ b/cluster-bootstrap/multicluster-observability/base/custom-metrics/custom-metrics.yaml
@@ -42,3 +42,5 @@ data:
       - kube_statefulset_replicas
       - acm_managed_cluster_info
       - kube_pod_start_time
+      - kube_endpoint_address_not_ready
+      - scrape_samples_scraped

--- a/cluster-bootstrap/multicluster-observability/base/custom-metrics/custom-metrics.yaml
+++ b/cluster-bootstrap/multicluster-observability/base/custom-metrics/custom-metrics.yaml
@@ -43,4 +43,5 @@ data:
       - acm_managed_cluster_info
       - kube_pod_start_time
       - kube_endpoint_address_not_ready
+      - kube_endpoint_address_available
       - scrape_samples_scraped


### PR DESCRIPTION
Add new alerts to monitor AAP:

- AAPMetricMissing: make sure the AAP metrics are valid
- AAPEndpointAddressNotReady: make sure the AAP endpoint is ready


Signed-off-by: Song Song Li <ssli@redhat.com>